### PR TITLE
fix missing utilities in Windows wheels

### DIFF
--- a/build.py
+++ b/build.py
@@ -1194,11 +1194,15 @@ def windeployqt_list_source(
                 target,
             ],
             stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             # ugh, 3.5
             # encoding='utf-8',
         )
     except subprocess.CalledProcessError as e:
-        raise DependencyCollectionError(target) from e
+        if 'does not seem to be a Qt executable' in e.stderr.decode('utf-8'):
+            # This can happen with some utilities like
+            # `rcc.exe`, which we still want to include.
+            return []
 
     paths = [
         pathlib.Path(line)


### PR DESCRIPTION
Some utilities, like `rcc.exe`, were getting filtered-out: handlethe fact that those are "not a Qt executable", as reported by `windeployqt`, but we still want to include them.

Close #21.